### PR TITLE
minor indenting issue fixed in bad example

### DIFF
--- a/src/Extras/VHDL/STD_01200_bad.vhd
+++ b/src/Extras/VHDL/STD_01200_bad.vhd
@@ -65,7 +65,7 @@ begin
    P_FlipFlop : process(i_Clock, i_Reset_n)
    begin
       if (i_Reset_n = '0') then Q <= '0'; else
-                                             if (rising_edge(i_Clock)) then Q <= i_D; end if;
+      if (rising_edge(i_Clock)) then Q <= i_D; end if;
    end if;
 end process;
 --CODE


### PR DESCRIPTION
bad examples may include wrong auto alignment, as in this case
